### PR TITLE
Update organization references in documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update --no-install-recommends && \
 WORKDIR /usr/src/app
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 
 RUN git clone https://github.com/${OPENCADC_REPO}/caom2tools.git && \
     cd caom2tools && \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ https://github.com/opencadc/collection2caom2/wiki/config.yml.
 1. Copy the file `config.yml` to the working directory. e.g.:
 
    ```
-   wget https://raw.github.com/opencadc/aico2caom2/main/config/config.yml
+   wget https://raw.github.com/opencadc-metadata-curation/aico2caom2/main/config/config.yml
    ```
 
 1. Tell `aico2caom2` in `config.yml` what to do with files on disk after the files have been stored to CADC:
@@ -81,8 +81,8 @@ https://github.com/opencadc/collection2caom2/wiki/config.yml.
 1. In the main branch of this repository, find the scripts directory, and copy the files `aico_run.sh`  and `aico_run_incremental.sh` to the working directory. e.g.:
 
    ```
-   wget https://raw.github.com/opencadc/aico2caom2/scripts/aico_run.sh
-   wget https://raw.github.com/opencadc/aico2caom2/scripts/aico_run_incremental.sh
+   wget https://raw.github.com/opencadc-metadata-curation/aico2caom2/scripts/aico_run.sh
+   wget https://raw.github.com/opencadc-metadata-curation/aico2caom2/scripts/aico_run_incremental.sh
    ```
 
 1. Ensure the scripts are executable:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 `aico2caom2` can store files from local disk to CADC storage. This behaviour is controlled by configuration
 information, located in a file named `config.yml`. Most of the `config.yml` values are already set appropriately, but there are a few values that need to be
 set according to the execution environment. For a complete description of the `config.yml` content, see
-https://github.com/opencadc/collection2caom2/wiki/config.yml.
+https://github.com/opencadc-metadata-curation/collection2caom2/wiki/config.yml.
 
 1. Copy the file `config.yml` to the working directory. e.g.:
 
@@ -147,8 +147,8 @@ Prepared files should be stored in a separate location for the next step, as `ai
    ```
 
 1. For some instructions that might be helpful on using containers, see:
-   https://github.com/opencadc/collection2caom2/wiki/Docker-and-Collections
+   https://github.com/opencadc-metadata-curation/collection2caom2/wiki/Docker-and-Collections
 
-1. For some insight into what's happening, see: https://github.com/opencadc/collection2caom2
+1. For some insight into what's happening, see: https://github.com/opencadc-metadata-curation/collection2caom2
 
 1. For Docker information, see: https://www.docker.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/aico2caom2
+github_project = opencadc-metadata-curation/aico2caom2
 install_requires =
     cadcdata
     cadctap


### PR DESCRIPTION
Update GitHub URLs in documentation from `opencadc` to `opencadc-metadata-curation` following repository transfer.

**Note:** Docker image references are not changed in this PR.